### PR TITLE
Two bug fixes in BKCommonLib

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/common/controller/EntityController.java
+++ b/src/main/java/com/bergerkiller/bukkit/common/controller/EntityController.java
@@ -264,7 +264,7 @@ public class EntityController<T extends CommonEntity<?>> extends CommonEntityCon
                 }
             }
             handle.locX = CommonNMS.getMiddleX(handle.getBoundingBox());
-            handle.locY = handle.getBoundingBox().b + (double) handle.length - (double) handle.U;
+            handle.locY = handle.getBoundingBox().b;
             handle.locZ = CommonNMS.getMiddleZ(handle.getBoundingBox());
             entity.setMovementImpaired(oldDx != dx || oldDz != dz);
             handle.onGround = oldDy != dy && oldDy < 0.0;

--- a/src/main/java/com/bergerkiller/bukkit/common/internal/CommonPlugin.java
+++ b/src/main/java/com/bergerkiller/bukkit/common/internal/CommonPlugin.java
@@ -404,7 +404,7 @@ public class CommonPlugin extends PluginBase {
                 "BKCommonLib isn't a plugin, its a language based on english.",
                 "Updating is like reinventing the wheel for BKCommonLib.",
                 "Say thanks to our wonderful devs: Friwi, KamikazePlatypus and mg_1999");
-        setEnableMessage(welcomeMessages.get(new Random().nextInt(welcomeMessages.size() + 1)));
+        setEnableMessage(welcomeMessages.get(new Random().nextInt(welcomeMessages.size())));
         setDisableMessage(null);
 
         // Initialize permissions


### PR DESCRIPTION
Fixed two bugs in BKCommonLib.

First in the welcomeMessages - it selected a random number up to welcomeMessages.size() + 1 meaning that sometimes the random number would be equal to welcomeMessages.size(). And when that happened it was Array Out of Bounds and the plugin failed to start.

Second is an update to match the underlying change in net.minecraft.server.Entity with regard to entity movement. This manifested in TrainCarts flying upwards when they derailed, or when the "Y" position changed at all. To test this you can build the pictured structure. With the unpatched code the minecart will fly upward when the track first slopes down. With the patch the minecart will properly stay on the track (including down and then up), fly off the end, and end up at the bottom of the ocean (or on the ground) as it should.

![image](https://cloud.githubusercontent.com/assets/4888254/8275646/905191c8-186f-11e5-865d-6d34ed99ebb5.png)

Note: I read somewhere about train carts climbing ladders. I've never set this up myself (however it works) so I don't know if this works with my change.