### PR TITLE
More granular entity categorization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.bergerkiller.bukkit</groupId>
     <artifactId>BKCommonLib</artifactId>
-    <version>1.65-SNAPSHOT</version>
+    <version>1.66-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>BKCommonLib</name>
@@ -16,9 +16,9 @@
         <project.mcversion>v1_8_R3</project.mcversion>
         <project.bversion>1.8.7-R0.1</project.bversion>
         <project.cbversion>1.8.6-R0.1</project.cbversion>
-        <project.stableversion>1.65</project.stableversion>
+        <project.stableversion>1.66</project.stableversion>
         <project.stableserver>1.8.7-R0.1</project.stableserver>
-        <project.stabledate>24 Juni 2015</project.stabledate>
+        <project.stabledate>30 June 2015</project.stabledate>
         <junit.version>4.11</junit.version>
     </properties>
 
@@ -96,6 +96,12 @@
             <systemPath>${project.basedir}/lib/ProtocolLib.jar</systemPath>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
         <!--
         <dependency>
             <groupId>com.googlecode.openpojo</groupId>
@@ -127,7 +133,6 @@
                 </includes>
             </resource>
         </resources>
-
         <!-- Plugins -->
         <plugins>
             <!-- Needed for shading in CGLib -->

--- a/src/main/java/com/bergerkiller/bukkit/common/utils/EntityGroupingUtil.java
+++ b/src/main/java/com/bergerkiller/bukkit/common/utils/EntityGroupingUtil.java
@@ -1,21 +1,27 @@
 package com.bergerkiller.bukkit.common.utils;
 
 import com.bergerkiller.bukkit.common.collections.StringMapCaseInsensitive;
+import com.bergerkiller.bukkit.common.internal.CommonPlugin;
+
 import org.bukkit.Material;
 import org.bukkit.entity.*;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.List;
 import java.util.Locale;
+import java.util.logging.Level;
 
 /**
  * Contains entity naming and grouping functions to categorize entities
  */
 public class EntityGroupingUtil {
 
-    private static final StringMapCaseInsensitive<EntityCategory> entityCategories = new StringMapCaseInsensitive<EntityCategory>();
+    private static final StringMapCaseInsensitive<Set<EntityCategory>> entityCategories = new StringMapCaseInsensitive<Set<EntityCategory>>();
     private static final EnumMap<EntityType, String> typeNames = new EnumMap<EntityType, String>(EntityType.class);
-    private static final Class<?>[] ANIMAL_CLASSES = {Animals.class, Squid.class};
-    private static final Class<?>[] MONSTER_CLASSES = {Monster.class, Slime.class, Ghast.class, Golem.class};
 
     static {
         // Note: These categories are ONLY used to map by name
@@ -34,45 +40,91 @@ public class EntityGroupingUtil {
             name = name.toLowerCase(Locale.ENGLISH);
 
             // Store it
-            entityCategories.put(name, getCategory(type));
+            if (entityCategories.containsKey(name)) {
+                Set<EntityCategory> x = entityCategories.get(name);
+                x.addAll(getCategories(type));
+                entityCategories.put(name, x);
+            } else {
+                Set<EntityCategory> x = new HashSet<EntityCategory>();
+                x.addAll(getCategories(type));
+                entityCategories.put(name, x);
+            }
             typeNames.put(type, name);
         }
     }
 
+    /**
+     * @deprecated Use Set<EntityCategory> getCategories(name)
+     */
+    @Deprecated
     public static EntityCategory getCategory(String name) {
-        return LogicUtil.fixNull(entityCategories.get(name), EntityCategory.OTHER);
+        Set<EntityCategory> x = getCategories(name);
+        for (EntityCategory entityCategory : EntityCategory.values()) {
+            if (entityCategory.isLegacyMob() && x.contains(entityCategory)) {
+                return entityCategory;
+            }
+        }
+        return EntityCategory.OTHER;
     }
 
+    /**
+     * @deprecated Use Set<EntityCategory> getCategories(entityType)
+     */
+    @Deprecated
     public static EntityCategory getCategory(EntityType type) {
         return getCategory(type.getEntityClass());
     }
 
+    /**
+     * @deprecated Use Set<EntityCategory> getCategories(entityClass)
+     */
+    @Deprecated
     public static EntityCategory getCategory(Class<? extends Entity> entityClass) {
-        if (isAnimal(entityClass)) {
-            return EntityCategory.ANIMAL;
-        } else if (isMonster(entityClass)) {
-            return EntityCategory.MONSTER;
-        } else if (isNPC(entityClass)) {
-            return EntityCategory.NPC;
-        } else {
-            return EntityCategory.OTHER;
+        Set<EntityCategory> x = getCategories(entityClass);
+        for (EntityCategory entityCategory : EntityCategory.values()) {
+            if (entityCategory.isLegacyMob() && x.contains(entityCategory)) {
+                return entityCategory;
+            }
         }
+        return EntityCategory.OTHER;
     }
 
+
+    /**
+     * Returns true if an entity is a mob
+     *
+     * @param name Name of the entity
+     * @return true if entity is a mob, false if entity is not a mob
+     */
     public static boolean isMob(String name) {
-        return getCategory(name).isMob();
+        return !(isEntityType(name, EntityCategory.OTHER));
     }
 
+    /**
+     * Returns true if an entity is a NPC
+     * @deprecated Use isEntityType(name, EntityCategory.NPC) instead
+     */
+    @Deprecated
     public static boolean isNPC(String name) {
-        return getCategory(name) == EntityCategory.NPC;
+        return isEntityType(name, EntityCategory.NPC);
     }
 
+    /**
+     * Returns true if an entity is an Animal
+     * @deprecated Use isEntityType(name, EntityCategory.ANIMAL) instead
+     */
+    @Deprecated
     public static boolean isAnimal(String name) {
-        return getCategory(name) == EntityCategory.ANIMAL;
+        return isEntityType(name, EntityCategory.ANIMAL);
     }
 
+    /**
+     * Returns true if an entity is a Monster
+     * @deprecated Use isEntityType(name, EntityCategory.MONSTER) instead
+     */
+    @Deprecated
     public static boolean isMonster(String name) {
-        return getCategory(name) == EntityCategory.MONSTER;
+        return isEntityType(name, EntityCategory.MONSTER);
     }
 
     public static boolean isMob(Entity entity) {
@@ -84,55 +136,341 @@ public class EntityGroupingUtil {
     }
 
     public static boolean isMob(Class<? extends Entity> entityClass) {
-        return isAnimal(entityClass) || isMonster(entityClass) || isNPC(entityClass);
+        Set<EntityCategory> resultSet = getCategories(entityClass);
+        return !(resultSet.contains(EntityCategory.OTHER));
     }
 
+    /**
+     * Returns true if an entity is a NPC
+     * @deprecated Use isEntityType(entity, EntityCategory.NPC) instead
+     */
+    @Deprecated
     public static boolean isNPC(Entity entity) {
-        return entity != null && isNPC(entity.getClass());
+        return isEntityType(entity, EntityCategory.NPC);
     }
 
+    /**
+     * Returns true if an entity is a NPC
+     * @deprecated Use isEntityType(entityType, EntityCategory.NPC) instead
+     */
+    @Deprecated
     public static boolean isNPC(EntityType entityType) {
-        return isNPC(entityType.getEntityClass());
+        return isEntityType(entityType, EntityCategory.NPC);
     }
 
+    /**
+     * Returns true if an entity is a NPC
+     * @deprecated Use isEntityType(class, EntityCategory.NPC) instead
+     */
+    @Deprecated
     public static boolean isNPC(Class<? extends Entity> entityClass) {
-        return entityClass != null && NPC.class.isAssignableFrom(entityClass);
+        return isEntityTypeClass(entityClass, EntityCategory.NPC);
     }
 
+    /**
+     * Returns true if an entity is an Animal
+     * @deprecated Use isEntityType(entity, EntityCategory.ANIMAL) instead
+     */
+    @Deprecated
     public static boolean isAnimal(Entity entity) {
-        return entity != null && isAnimal(entity.getClass());
+        return isEntityType(entity, EntityCategory.ANIMAL);
     }
 
+    /**
+     * Returns true if an entity is an Animal
+     * @deprecated Use isEntityType(entityType, EntityCategory.ANIMAL) instead
+     */
+    @Deprecated
     public static boolean isAnimal(EntityType entityType) {
-        return isAnimal(entityType.getEntityClass());
+        return isEntityType(entityType, EntityCategory.ANIMAL);
     }
 
+    /**
+     * Returns true if an entity is an Animal
+     * @deprecated Use isEntityType(class, EntityCategory.ANIMAL) instead
+     */
+    @Deprecated
     public static boolean isAnimal(Class<? extends Entity> entityClass) {
-        if (entityClass == null) {
-            return false;
+        return isEntityTypeClass(entityClass, EntityCategory.ANIMAL);
+    }
+
+    /**
+     * Returns true if an entity is a Monster
+     * @deprecated Use isEntityType(entity, EntityCategory.MONSTER) instead
+     */
+    @Deprecated
+    public static boolean isMonster(Entity entity) {
+        return isEntityType(entity, EntityCategory.MONSTER);
+    }
+
+    /**
+     * Returns true if an entity is a Monster
+     * @deprecated Use isEntityType(entityType, EntityCategory.MONSTER) instead
+     */
+    @Deprecated
+    public static boolean isMonster(EntityType entityType) {
+        return isEntityType(entityType, EntityCategory.MONSTER);
+    }
+
+    /**
+     * Returns true if an entity is a Monster
+     * @deprecated Use isEntityType(name, EntityCategory.MONSTER) instead
+     */
+    @Deprecated
+    public static boolean isMonster(Class<? extends Entity> entityClass) {
+        return isEntityTypeClass(entityClass, EntityCategory.MONSTER);
+    }
+
+    /**
+     * Returns true if an entity is a killer bunny
+     *
+     * @param entity The entity to check
+     * @result Returns true if an entity is a killer bunny
+     */
+    public static boolean isKillerBunny(Entity entity) {
+        if (isEntityTypeClass(entity, Rabbit.class)) {
+            return ((Rabbit)entity).getRabbitType() == Rabbit.Type.THE_KILLER_BUNNY;
         }
-        for (Class<?> animalClass : ANIMAL_CLASSES) {
-            if (animalClass.isAssignableFrom(entityClass)) {
+        return false;
+    }
+
+    /**
+     * Returns true if an entity is tamed
+     *
+     * @param entity The entity to check
+     * @result Returns true if an entity is tamed
+     */
+    public static boolean isTamed(Entity entity) {
+        if (isEntityType(entity, EntityCategory.TAMEABLE)) {
+            return ((Tameable)entity).isTamed();
+        }
+        return false;
+    }
+
+    /**
+     * Jockeys:<br>
+     * - Skeleton riding spider<br>
+     * - Zombie riding chicken
+     *
+     * @param entity The entity to check
+     * @result Returns true if the entity is a jockey
+     */
+    public static boolean isJockey(Entity entity) {
+        if (isEntityTypeClass(entity, Spider.class)) {
+            return hasMobOnTopOrBottom(entity, Zombie.class);
+        } else if (isEntityTypeClass(entity, Chicken.class)) {
+            return hasMobOnTopOrBottom(entity, Skeleton.class);
+        } else if (isEntityTypeClass(entity, Zombie.class)) {
+            return hasMobOnTopOrBottom(entity, Chicken.class);
+        } else if (isEntityTypeClass(entity, Skeleton.class)) {
+            return hasMobOnTopOrBottom(entity, Spider.class);
+        }
+        return false;
+    }
+
+    private static boolean hasMobOnTopOrBottom(Entity e, Class<?> searchMobType) {
+        List<Entity> mobs = e.getNearbyEntities(0.5, 1.0, 0.5);
+        for (Entity mob : mobs) {
+            if (isEntityTypeClass(mob, searchMobType)) {
                 return true;
             }
         }
         return false;
     }
 
-    public static boolean isMonster(Entity entity) {
-        return entity != null && isMonster(entity.getClass());
+    /**
+     * Returns a set of all matching categories
+     *
+     * @param name The name of the entity type
+     * @return Set<EntityCategory> of all matching categories
+     */
+    public static Set<EntityCategory> getCategories(String name) {
+        Set<EntityCategory> x = new HashSet<EntityCategory>();
+        x.add(EntityCategory.OTHER);
+        return LogicUtil.fixNull(entityCategories.get(name), x);
     }
 
-    public static boolean isMonster(EntityType entityType) {
-        return isMonster(entityType.getEntityClass());
+    /**
+     * Returns a set of all matching categories
+     *
+     * @param type The EntityType
+     * @return Set<EntityCategory> of all matching categories
+     */
+    public static Set<EntityCategory> getCategories(EntityType type) {
+        return getCategories(type.getEntityClass());
     }
 
-    public static boolean isMonster(Class<? extends Entity> entityClass) {
-        if (entityClass == null) {
-            return false;
+    /**
+     * Returns a set of all matching categories
+     *
+     * @param entity The Entity
+     * @return Set<EntityCategory> of all matching categories
+     */
+    public static Set<EntityCategory> getCategories(Entity entity) {
+        Set<EntityCategory> resultSet = new HashSet<EntityCategory>();
+        if (isKillerBunny(entity)) {
+            resultSet.add(EntityCategory.KILLER_BUNNY);
+            resultSet.add(EntityCategory.ANIMAL);
+            resultSet.add(EntityCategory.HOSTILE);
         }
-        for (Class<?> monsterClass : MONSTER_CLASSES) {
-            if (monsterClass.isAssignableFrom(entityClass)) {
+        if (isTamed(entity)) {
+            resultSet.add(EntityCategory.TAMED);
+        }
+        if (isJockey(entity)) {
+            resultSet.add(EntityCategory.JOCKEY);
+            resultSet.add(EntityCategory.MONSTER);
+            resultSet.add(EntityCategory.ANIMAL);
+            resultSet.add(EntityCategory.HOSTILE);
+        }
+        addMatchingCategories(resultSet, entity);
+        if (resultSet.size() == 0) {
+            resultSet.add(EntityCategory.OTHER);
+        }
+        return resultSet;
+    }
+
+    /**
+     * Returns a set of all matching categories
+     *
+     * @param entityClass The Entity class
+     * @return Set<EntityCategory> of all matching categories
+     */
+    public static Set<EntityCategory> getCategories(Class<? extends Entity> entityClass) {
+        Set<EntityCategory> resultSet = new HashSet<EntityCategory>();
+        addMatchingCategories(resultSet, entityClass);
+        if (resultSet.size() == 0) {
+            resultSet.add(EntityCategory.OTHER);
+        }
+        return resultSet;
+    }
+
+    private static void addMatchingCategories(Set<EntityCategory> resultSet, Entity e) {
+        addMatchingCategories(resultSet, e.getClass());
+    }
+
+    private static void addMatchingCategories(Set<EntityCategory> resultSet, Class<?> class1) {
+        if (class1 == null) {
+            return;
+        }
+        for (EntityCategory entityCategory : EntityCategory.values()) {
+            Set<Class<?>> entityClasses = entityCategory.getEntityClasses();
+            for (Class<?> entityClass : entityClasses) {
+                if (entityClass.isAssignableFrom(class1)) {
+                    resultSet.add(entityCategory);
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns true if the entity named "name" belongs to the specified entity category
+     *
+     * @param name The Entity name
+     * @param entityCategory The entity category to consider
+     * @return True if the specified entity belongs to the specified entity category
+     */
+    public static boolean isEntityType(String name, EntityCategory entityCategory) {
+        return getCategories(name).contains(entityCategory);
+    }
+
+    /**
+     * Returns true if the entity belongs to the specified class of entities
+     *
+     * @param entity The Entity object
+     * @param entityClass The class to consider if the entity belongs
+     * @return True if the specified entity belongs to the specified entity class
+     */
+    public static boolean isEntityTypeClass(Entity entity, Class<?> entityClass) {
+        return entity != null && isEntityTypeClass(entity.getClass(), entityClass);
+    }
+
+    /**
+     * Returns true if the entity belongs to any of the given entity classes
+     *
+     * @param entity The Entity object
+     * @param entityClassSet A set of classes to be considered
+     * @return True if the specified entity belongs to any of the classes in entityClassSet
+     */
+    public static boolean isEntityTypeClass(Entity entity, Set<Class<?>> entityClassSet) {
+        if (entity != null) {
+            for (Class<?> myClass : entityClassSet) {
+                if (isEntityTypeClass(entity.getClass(), myClass)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the entity belongs to the given entity category
+     *
+     * @param entity The Entity object
+     * @param entityCategory Entity category to consider
+     * @return True if the specified entity belongs to the entityCategory
+     */
+    public static boolean isEntityType(Entity entity, EntityCategory entityCategory) {
+        return entity != null && getCategories(entity.getClass()).contains(entityCategory);
+    }
+
+    /**
+     * Returns true if the entity belongs to any of the categories in the given set
+     *
+     * @param entity The Entity object
+     * @param entityCategorySet Set of entity categories to consider
+     * @return True if the specified entity belongs to any of the categories in entityCategorySet
+     */
+    public static boolean isEntityType(Entity entity, Set<EntityCategory> entityCategorySet) {
+        if (entity != null) {
+            Set<EntityCategory> thisEntityCategories = getCategories(entity.getClass());
+            if (thisEntityCategories.size() == 1 && thisEntityCategories.contains(EntityCategory.OTHER)) {
+                if (entityCategorySet.size() == 1 && entityCategorySet.contains(EntityCategory.OTHER)) {
+                    return true;
+                }
+                return false;
+            }
+            for (EntityCategory x : entityCategorySet) {
+                if (thisEntityCategories.contains(x)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the entity type belongs to the given entity category
+     *
+     * @param entityType The Entity type
+     * @param entityCategory The entity category to consider
+     * @return True if the specified entity type belongs to the given entity category
+     */
+    public static boolean isEntityType(EntityType entityType, EntityCategory entityCategory) {
+        return getCategories(entityType.getEntityClass()).contains(entityCategory);
+    }
+
+    /**
+     * Returns true if the class of entity is assignable to another class
+     *
+     * @param entityClass The class of entity
+     * @param testEntityClass The class to consider whether the entity class is assignable
+     * @return True if the specified entity class is assignable to the specified test class
+     */
+    public static boolean isEntityTypeClass(Class<?> entityClass, Class<?> testEntityClass) {
+        return testEntityClass.isAssignableFrom(entityClass);
+    }
+
+    /**
+     * Returns true if the class of entity belongs to the specified entity category
+     *
+     * @param entityClass The class of entity
+     * @param entityCategory The category to consider if the entity class belongs
+     * @return True if the class of entity belongs to the specified entity category
+     */
+    public static boolean isEntityTypeClass(Class<?> entityClass, EntityCategory entityCategory) {
+        for (Class<?> myClass : entityCategory.getEntityClasses()) {
+            if (myClass.isAssignableFrom(entityClass)) {
                 return true;
             }
         }
@@ -203,17 +541,90 @@ public class EntityGroupingUtil {
      * Represents a certain category of entities
      */
     public static enum EntityCategory {
-
-        ANIMAL(true), MONSTER(true), NPC(true), OTHER(false);
+        KILLER_BUNNY(true, false, "isKillerBunny"),
+        TAMED(true, false, "isTamed"),
+        JOCKEY(true, false, "isJockey"),
+        ANIMAL(true, true, Animals.class, Squid.class),
+        MONSTER(true, true, Monster.class, Slime.class, Ghast.class, Golem.class),
+        NPC(true, true, NPC.class),
+        PASSIVE(true, false, Bat.class, Chicken.class, Cow.class, MushroomCow.class, Pig.class, Sheep.class, Squid.class, Villager.class),
+        NEUTRAL(true, false, CaveSpider.class, Enderman.class, Spider.class, PigZombie.class),
+        HOSTILE(true, false, Blaze.class, Creeper.class, Guardian.class, Endermite.class, Ghast.class, MagmaCube.class, Silverfish.class, Skeleton.class, Slime.class, Witch.class, Zombie.class),
+        TAMEABLE(true, false, Tameable.class),
+        UTILITY(true, false, Golem.class),
+        BOSS(true, false, EnderDragon.class, EnderDragonPart.class, Wither.class),
+        OTHER(false, true);
 
         private final boolean isMob;
+        private boolean isLegacyMob;
+        private Set<Class<?>> entityClasses;
+        private Method method;
 
-        private EntityCategory(boolean isMob) {
+        private EntityCategory(boolean isMob, boolean isLegacyMob) {
             this.isMob = isMob;
+            this.isLegacyMob = isLegacyMob;
+            this.setEntityClasses();
+            this.setMethod(null);
+        }
+
+        private EntityCategory(boolean isMob, boolean isLegacyMob, Class<?>...classes) {
+            this.isMob = isMob;
+            this.isLegacyMob = isLegacyMob;
+            this.setMethod(null);
+            this.setEntityClasses(classes);
+        }
+
+        private EntityCategory(boolean isMob, boolean isLegacyMob, String methodName) {
+            this.isMob = isMob;
+            this.isLegacyMob = isLegacyMob;
+            this.setEntityClasses();
+            try {
+                Method methodTry = (EntityGroupingUtil.class).getMethod(methodName, Entity.class);
+                this.setMethod(methodTry);
+            } catch (Exception e) {
+                CommonPlugin.LOGGER.log(Level.WARNING, String.format("Unable to reference method %s(Entity) in EntityGroupingUtil: %s", methodName, e.getMessage()));
+                this.setMethod(null);
+            }
+        }
+
+        private void setEntityClasses() {
+            this.entityClasses = new HashSet<Class<?>>();
         }
 
         public boolean isMob() {
             return isMob;
+        }
+
+        /*
+         * Adding this so the calls to getCategory() still return what they used to,
+         * whereas calls to getCategories() will return the full list.
+         */
+        public boolean isLegacyMob() {
+            return isLegacyMob;
+        }
+
+        public Set<Class<?>> getEntityClasses() {
+            return entityClasses;
+        }
+
+        public void setEntityClasses(Set<Class<?>> entityClasses) {
+            this.entityClasses = entityClasses;
+        }
+
+        public void setEntityClasses(Class<?>[] entityClasses) {
+            this.setEntityClasses(new HashSet<Class<?>>(Arrays.asList(entityClasses)));
+        }
+
+        public Method getMethod() {
+            return method;
+        }
+
+        public void setMethod(Method method) {
+            this.method = method;
+        }
+
+        public boolean contains(Class<?> entityClass) {
+            return this.getEntityClasses().contains(entityClass);
         }
     }
 }

--- a/src/test/java/com/bergerkiller/bukkit/common/utils/EntityGroupingUtilTest.java
+++ b/src/test/java/com/bergerkiller/bukkit/common/utils/EntityGroupingUtilTest.java
@@ -1,0 +1,419 @@
+package com.bergerkiller.bukkit.common.utils;
+
+import static org.junit.Assert.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.bergerkiller.bukkit.common.utils.EntityGroupingUtil;
+import com.bergerkiller.bukkit.common.utils.EntityGroupingUtil.EntityCategory;
+
+import org.bukkit.entity.*;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class EntityGroupingUtilTest {
+
+    public static Entity generateEntity(EntityType entityType) {
+        return generateEntity(entityType.getEntityClass());
+    }
+
+    public static Entity generateEntity(Class<?> entityClass) {
+        return (Entity) mock(entityClass);
+    }
+
+    @Test
+    public void testGetCategoryString() {
+        for (EntityTestList test : EntityTestList.values()) {
+            if (test.isLegacyField()) {
+                @SuppressWarnings("deprecation")
+                EntityCategory result1 = EntityGroupingUtil.getCategory(test.getMatching().getName().toLowerCase());
+                assertSame(String.format("%s: (%s) == (%s)", test.name(), test.getEntityCategory().name(), result1.toString()), result1, test.getEntityCategory());
+
+                @SuppressWarnings("deprecation")
+                EntityCategory result2 = EntityGroupingUtil.getCategory(test.getNonMatching().getName().toLowerCase());
+                assertNotSame(String.format("%s: (%s) != (%s)", test.name(), test.getEntityCategory().name(), result2.toString()), result2, test.getEntityCategory());
+            }
+        }
+    }
+
+    @Test
+    public void testGetCategoriesString() {
+        for (EntityTestList test : EntityTestList.values()) {
+            @SuppressWarnings("deprecation")
+            Set<EntityCategory> result1 = EntityGroupingUtil.getCategories(test.getMatching().getName().toLowerCase());
+            assertTrue(String.format("%s: (%s) == (%s)", test.name(), test.getEntityCategory().name(), result1.toString()), result1.contains(test.getEntityCategory()));
+
+            @SuppressWarnings("deprecation")
+            Set<EntityCategory> result2 = EntityGroupingUtil.getCategories(test.getNonMatching().getName().toLowerCase());
+            assertTrue(String.format("%s: (%s) != (%s)", test.name(), test.getEntityCategory().name(), result2.toString()), result1.contains(test.getEntityCategory()));
+        }
+    }
+
+    @Test
+    public void testGetCategoryEntityType() {
+        for (EntityTestList test : EntityTestList.values()) {
+            if (test.isLegacyField()) {
+                @SuppressWarnings("deprecation")
+                EntityCategory result1 = EntityGroupingUtil.getCategory(test.getMatching());
+                assertSame("Matching " + test.name(), result1, test.getEntityCategory());
+
+                @SuppressWarnings("deprecation")
+                EntityCategory result2 = EntityGroupingUtil.getCategory(test.getNonMatching());
+                assertNotSame("Non-Matching " + test.name(), result2, test.getEntityCategory());
+            }
+        }
+    }
+
+    @Test
+    public void testGetCategoriesEntityType() {
+        for (EntityTestList test : EntityTestList.values()) {
+            Set<EntityCategory> result1 = EntityGroupingUtil.getCategories(test.getMatching());
+            assertTrue(String.format("%s: (%s) == (%s)", test.name(), test.getEntityCategory().name(), result1.toString()), result1.contains(test.getEntityCategory()));
+
+            Set<EntityCategory> result2 = EntityGroupingUtil.getCategories(test.getNonMatching());
+            assertTrue(String.format("%s: (%s) != (%s)", test.name(), test.getEntityCategory().name(), result2.toString()), result1.contains(test.getEntityCategory()));
+        }
+    }
+
+    @Test
+    public void testGetCategoryClassOfQextendsEntity() {
+        for (EntityTestList test : EntityTestList.values()) {
+            if (test.isLegacyField()) {
+                @SuppressWarnings("deprecation")
+                EntityCategory result1 = EntityGroupingUtil.getCategory(test.getMatching().getEntityClass());
+                assertSame("Matching " + test.name(), result1, test.getEntityCategory());
+
+                @SuppressWarnings("deprecation")
+                EntityCategory result2 = EntityGroupingUtil.getCategory(test.getNonMatching().getEntityClass());
+                assertNotSame("Non-Matching " + test.name(), result2, test.getEntityCategory());
+            }
+        }
+    }
+
+    @Test
+    public void testGetCategoriesEntity() {
+        for (EntityTestList test : EntityTestList.values()) {
+            Entity entity1 = generateEntity(test.getMatching());
+            Set<EntityCategory> result1 = EntityGroupingUtil.getCategories(entity1);
+            assertTrue(String.format("%s: (%s) == (%s)", test.name(), test.getEntityCategory().name(), result1.toString()), result1.contains(test.getEntityCategory()));
+
+            Entity entity2 = generateEntity(test.getNonMatching());
+            Set<EntityCategory> result2 = EntityGroupingUtil.getCategories(entity2);
+            assertTrue(String.format("%s: (%s) != (%s)", test.name(), test.getEntityCategory().name(), result2.toString()), result1.contains(test.getEntityCategory()));
+        }
+    }
+
+    @Test
+    public void testGetCategoriesClassOfQextendsEntity() {
+        for (EntityTestList test : EntityTestList.values()) {
+            Set<EntityCategory> result1 = EntityGroupingUtil.getCategories(test.getMatching().getEntityClass());
+            assertTrue(String.format("%s: (%s) == (%s)", test.name(), test.getEntityCategory().name(), result1.toString()), result1.contains(test.getEntityCategory()));
+
+            Set<EntityCategory> result2 = EntityGroupingUtil.getCategories(test.getNonMatching().getEntityClass());
+            assertTrue(String.format("%s: (%s) != (%s)", test.name(), test.getEntityCategory().name(), result2.toString()), result1.contains(test.getEntityCategory()));
+        }
+    }
+
+    @Test
+    public void testIsEntityTypeStringEntityCategory() {
+        for (EntityTestList test : EntityTestList.values()) {
+            @SuppressWarnings("deprecation")
+            boolean result1 = EntityGroupingUtil.isEntityType(test.getMatching().getName(), test.getEntityCategory());
+            assertTrue(String.format("%s: (%s) == (%s)", test.name(), test.getMatching().name(), test.getEntityCategory().name()), result1);
+
+            @SuppressWarnings("deprecation")
+            boolean result2 = EntityGroupingUtil.isEntityType(test.getNonMatching().getName(), test.getEntityCategory());
+            assertFalse(String.format("%s: (%s) != (%s)", test.name(), test.getNonMatching().name(), test.getEntityCategory().name()), result2);
+       }
+    }
+
+    @Test
+    public void testIsEntityTypeClassEntityClassOfQ() {
+        for (EntityTestList test : EntityTestList.values()) {
+            Entity entity1 = generateEntity(test.getMatching());
+            boolean result1 = EntityGroupingUtil.isEntityTypeClass(entity1, test.getMatching().getEntityClass());
+            assertTrue(String.format("%s: (%s) == (%s)", test.name(), test.getMatching().name(), test.getEntityCategory().name()), result1);
+
+            Entity entity2 = generateEntity(test.getNonMatching());
+            boolean result2 = EntityGroupingUtil.isEntityTypeClass(entity2, test.getMatching().getEntityClass());
+            assertFalse(String.format("%s: (%s) != (%s)", test.name(), test.getNonMatching().name(), test.getEntityCategory().name()), result2);
+       }
+    }
+
+    @Test
+    public void testIsEntityTypeClassEntitySetOfClassOfQ() {
+        for (EntityTestList test : EntityTestList.values()) {
+            Entity entity1 = generateEntity(test.getMatching());
+            boolean result1 = EntityGroupingUtil.isEntityTypeClass(entity1, test.getEntityCategory().getEntityClasses());
+            assertTrue(String.format("%s: (%s) == (%s)", test.name(), test.getMatching().name(), test.getEntityCategory().getEntityClasses().toString()), result1);
+
+            Entity entity2 = generateEntity(test.getNonMatching());
+            boolean result2 = EntityGroupingUtil.isEntityTypeClass(entity2, test.getEntityCategory().getEntityClasses());
+            assertFalse(String.format("%s: (%s) != (%s)", test.name(), test.getNonMatching().name(), test.getEntityCategory().getEntityClasses().toString()), result2);
+       }
+    }
+
+    @Test
+    public void testIsEntityTypeEntityEntityCategory() {
+        for (EntityTestList test : EntityTestList.values()) {
+            Entity entity1 = generateEntity(test.getMatching());
+            boolean result1 = EntityGroupingUtil.isEntityType(entity1, test.getEntityCategory());
+            assertTrue(String.format("%s: (%s) == (%s)", test.name(), test.getMatching().name(), test.getEntityCategory().toString()), result1);
+
+            Entity entity2 = generateEntity(test.getNonMatching());
+            boolean result2 = EntityGroupingUtil.isEntityType(entity2, test.getEntityCategory());
+            assertFalse(String.format("%s: (%s) != (%s)", test.name(), test.getNonMatching().name(), test.getEntityCategory().toString()), result2);
+       }
+    }
+
+    @Test
+    public void testIsEntityTypeEntitySetOfEntityCategory() {
+        for (EntityTestList test : EntityTestList.values()) {
+            Entity entity1 = generateEntity(test.getMatching());
+            Set<EntityCategory> set1 = new HashSet<EntityCategory>();
+            set1.add(test.getEntityCategory());
+            boolean result1 = EntityGroupingUtil.isEntityType(entity1, set1);
+            assertTrue(String.format("%s: (%s) == (%s)", test.name(), test.getMatching().name(), set1.toString()), result1);
+
+            Entity entity2 = generateEntity(test.getNonMatching());
+            Set<EntityCategory> set2 = new HashSet<EntityCategory>();
+            set2.add(test.getEntityCategory());
+            boolean result2 = EntityGroupingUtil.isEntityType(entity2, set2);
+            assertFalse(String.format("%s: (%s) != (%s)", test.name(), test.getNonMatching().name(), set2.toString()), result2);
+       }
+    }
+
+    @Test
+    public void testIsEntityTypeEntityTypeEntityCategory() {
+        for (EntityTestList test : EntityTestList.values()) {
+            boolean result1 = EntityGroupingUtil.isEntityType(test.getMatching(), test.getEntityCategory());
+            assertTrue(String.format("%s: (%s) == (%s)", test.name(), test.getMatching().name(), test.getEntityCategory()), result1);
+
+            boolean result2 = EntityGroupingUtil.isEntityType(test.getNonMatching(), test.getEntityCategory());
+            assertFalse(String.format("%s: (%s) == (%s)", test.name(), test.getMatching().name(), test.getEntityCategory()), result2);
+       }
+    }
+
+    @Test
+    public void testIsEntityTypeClassClassOfQClassOfQ() {
+        for (EntityTestList test : EntityTestList.values()) {
+            boolean result1 = EntityGroupingUtil.isEntityTypeClass(test.getMatching().getEntityClass(), test.getMatching().getEntityClass());
+            assertTrue(String.format("%s: (%s) == (%s)", test.name(), test.getMatching().name(), test.getEntityCategory()), result1);
+
+            boolean result2 = EntityGroupingUtil.isEntityTypeClass(test.getNonMatching().getEntityClass(), test.getMatching().getEntityClass());
+            assertFalse(String.format("%s: (%s) == (%s)", test.name(), test.getMatching().name(), test.getEntityCategory()), result2);
+       }
+    }
+
+    @Test
+    public void testIsEntityTypeClassClassOfQEntityCategory() {
+        for (EntityTestList test : EntityTestList.values()) {
+            boolean result1 = EntityGroupingUtil.isEntityTypeClass(test.getMatching().getEntityClass(), test.getEntityCategory());
+            assertTrue(String.format("%s: (%s) == (%s)", test.name(), test.getMatching().name(), test.getEntityCategory()), result1);
+
+            boolean result2 = EntityGroupingUtil.isEntityTypeClass(test.getNonMatching().getEntityClass(), test.getEntityCategory());
+            assertFalse(String.format("%s: (%s) == (%s)", test.name(), test.getMatching().name(), test.getEntityCategory()), result2);
+       }
+    }
+
+    @Test
+    public void testIsMobString() {
+        for (EntityTestList test : EntityTestList.values()) {
+            if (test.isLegacyField()) {
+                boolean result1 = EntityGroupingUtil.isMob(test.getMatching().name());
+                assertTrue(String.format("%s: isMob(%s)", test.name(), test.getMatching().name()), result1);
+            }
+        }
+        boolean result2 = EntityGroupingUtil.isMob("minecart");
+        assertFalse(String.format("isMob(%s)", "minecart"), result2);
+    }
+
+    @Test
+    public void testIsMobEntity() {
+        for (EntityTestList test : EntityTestList.values()) {
+            if (test.isLegacyField()) {
+                Entity entity = generateEntity(test.getMatching().getEntityClass());
+                boolean result1 = EntityGroupingUtil.isMob(entity);
+                assertTrue(String.format("%s: isMob(%s)", test.name(), test.getMatching().name()), result1);
+            }
+        }
+        Entity entity = generateEntity(Minecart.class);
+        boolean result2 = EntityGroupingUtil.isMob(entity);
+        assertFalse(String.format("isMob(%s)", "minecart entity"), result2);
+    }
+
+    @Test
+    public void testIsMobEntityType() {
+        for (EntityTestList test : EntityTestList.values()) {
+            if (test.isLegacyField()) {
+                boolean result1 = EntityGroupingUtil.isMob(test.getMatching());
+                assertTrue(String.format("%s: isMob(%s entity type)", test.name(), test.getMatching().name()), result1);
+            }
+        }
+        boolean result2 = EntityGroupingUtil.isMob(EntityType.MINECART);
+        assertFalse(String.format("isMob(%s)", "minecart entity type"), result2);
+    }
+
+    @Test
+    public void testIsMobClassOfQextendsEntity() {
+        for (EntityTestList test : EntityTestList.values()) {
+            if (test.isLegacyField()) {
+                boolean result1 = EntityGroupingUtil.isMob(test.getMatching().getEntityClass());
+                assertTrue(String.format("%s: isMob(%s class)", test.name(), test.getMatching().name()), result1);
+            }
+        }
+        boolean result2 = EntityGroupingUtil.isMob(Minecart.class);
+        assertFalse(String.format("isMob(%s)", "minecart class"), result2);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testIsNPCString() {
+        assertTrue("Villager is NPC", EntityGroupingUtil.isNPC("villager"));
+        assertFalse("Zombie is not NPC", EntityGroupingUtil.isNPC("zombie"));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testIsNPCEntity() {
+        Entity villager = generateEntity(Villager.class);
+        Entity zombie = generateEntity(Zombie.class);
+        assertTrue("Villager is NPC", EntityGroupingUtil.isNPC(villager));
+        assertFalse("Zombie is not NPC", EntityGroupingUtil.isNPC(zombie));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testIsNPCEntityType() {
+        assertTrue("Villager is NPC", EntityGroupingUtil.isNPC(EntityType.VILLAGER));
+        assertFalse("Zombie is not NPC", EntityGroupingUtil.isNPC(EntityType.ZOMBIE));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testIsNPCClassOfQextendsEntity() {
+        assertTrue("Villager is NPC", EntityGroupingUtil.isNPC(Villager.class));
+        assertFalse("Zombie is not NPC", EntityGroupingUtil.isNPC(Zombie.class));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testIsAnimalString() {
+        assertTrue("Sheep is Animal", EntityGroupingUtil.isAnimal("sheep"));
+        assertFalse("Zombie is not Animal", EntityGroupingUtil.isAnimal("zombie"));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testIsAnimalEntity() {
+        Entity sheep = generateEntity(Sheep.class);
+        Entity zombie = generateEntity(Zombie.class);
+        assertTrue("Sheep is Animal", EntityGroupingUtil.isAnimal(sheep));
+        assertFalse("Zombie is not Animal", EntityGroupingUtil.isAnimal(zombie));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testIsAnimalEntityType() {
+        assertTrue("Sheep is Animal", EntityGroupingUtil.isAnimal(EntityType.SHEEP));
+        assertFalse("Zombie is not Animal", EntityGroupingUtil.isAnimal(EntityType.ZOMBIE));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testIsAnimalClassOfQextendsEntity() {
+        assertTrue("Sheep is Animal", EntityGroupingUtil.isAnimal(Sheep.class));
+        assertFalse("Zombie is not Animal", EntityGroupingUtil.isAnimal(Zombie.class));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testIsMonsterString() {
+        assertTrue("Zombie is Monster", EntityGroupingUtil.isMonster("zombie"));
+        assertFalse("Sheep is not Monster", EntityGroupingUtil.isMonster("sheep"));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testIsMonsterEntity() {
+        Entity sheep = generateEntity(Sheep.class);
+        Entity zombie = generateEntity(Zombie.class);
+        assertTrue("Zombie is Monster", EntityGroupingUtil.isMonster(zombie));
+        assertFalse("Sheep is not Monster", EntityGroupingUtil.isMonster(sheep));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testIsMonsterEntityType() {
+        assertTrue("Zombie is Monster", EntityGroupingUtil.isMonster(EntityType.ZOMBIE));
+        assertFalse("Sheep is not Monster", EntityGroupingUtil.isMonster(EntityType.SHEEP));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testIsMonsterClassOfQextendsEntity() {
+        assertTrue("Zombie is Monster", EntityGroupingUtil.isMonster(Zombie.class));
+        assertFalse("Sheep is not Monster", EntityGroupingUtil.isMonster(Sheep.class));
+    }
+
+    @Test
+    public void testGetNameClassOfQextendsEntity() {
+        assertEquals("Zombie.class = zombie", "zombie", EntityGroupingUtil.getName(Zombie.class));
+    }
+
+    @Test
+    public void testGetNameEntityType() {
+        assertEquals("Zombie type = zombie", "zombie", EntityGroupingUtil.getName(EntityType.ZOMBIE));
+    }
+
+    public static enum EntityTestList {
+        ANIMAL_TEST(EntityCategory.ANIMAL, EntityType.SHEEP, EntityType.ZOMBIE, true),
+        MONSTER_TEST(EntityCategory.MONSTER, EntityType.ZOMBIE, EntityType.SHEEP, true),
+        NPC_TEST(EntityCategory.NPC, EntityType.VILLAGER, EntityType.ZOMBIE, true),
+        PASSIVE_TEST(EntityCategory.PASSIVE, EntityType.SHEEP, EntityType.ZOMBIE, false),
+        HOSTILE_TEST(EntityCategory.HOSTILE, EntityType.ZOMBIE, EntityType.SHEEP, false),
+        UTILITY_TEST(EntityCategory.UTILITY, EntityType.IRON_GOLEM, EntityType.SHEEP, false),
+        BOSS_TEST(EntityCategory.BOSS, EntityType.WITHER, EntityType.SHEEP, false),
+        TAMEABLE_TEST(EntityCategory.TAMEABLE, EntityType.OCELOT, EntityType.SHEEP, false);
+
+        private EntityCategory entityCategory;
+        private EntityType matching;
+        private EntityType nonMatching;
+        private boolean legacyField;
+        private EntityTestList (EntityCategory entityCategory, EntityType matching, EntityType nonMatching, boolean legacyField) {
+            this.setEntityCategory(entityCategory);
+            this.setLegacyField(legacyField);
+            this.setMatching(matching);
+            this.setNonMatching(nonMatching);
+        }
+        public EntityCategory getEntityCategory() {
+            return entityCategory;
+        }
+        public void setEntityCategory(EntityCategory entityCategory) {
+            this.entityCategory = entityCategory;
+        }
+        public EntityType getMatching() {
+            return matching;
+        }
+        public void setMatching(EntityType matching) {
+            this.matching = matching;
+        }
+        public EntityType getNonMatching() {
+            return nonMatching;
+        }
+        public void setNonMatching(EntityType nonMatching) {
+            this.nonMatching = nonMatching;
+        }
+        public boolean isLegacyField() {
+            return legacyField;
+        }
+        public void setLegacyField(boolean legacyField) {
+            this.legacyField = legacyField;
+        }
+
+
+    }
+
+}


### PR DESCRIPTION
This is needed to support my recent updates to TrainCarts.

Preserved all existing methods: isMob(), isAnimal(), isMonster(), isNPC(), getCategory(). All of these except isMob() are now marked as deprecated with suggestions on better methods to use.

Rewrote (for the most part) the entity categorization logic:
- Added support for new entity types in 1.8: killer bunnies
- Added support for detecting pets (tamed animals) and jockeys
- Added support for classifying mobs based on minecraft wiki (passive, neutral, hostile, utility, boss, tameable)

Put all of the mob classifications in an ENUM so this can be easily changed or extended without rewriting lots of code.

Added new and more flexible methods:
- getCategories() - entities may fall into more than one category (e.g. a creeper is both hostile and monster) and this returns those as a set. Intended as replacement for old getCategory() methods which returned a single category.
- isEntityType() and isEntityTypeClass() - more flexible ways of determining if an entity is in a particular class. Intended as a replacement for old methods like isAnimal(), isMonster(), etc.

Added a bunch of javadoc comments to old and new methods alike.

Wrote tests for the old and new methods.