### PR TITLE
Fix detection for Paper servers

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/common/server/PaperSpigotServer.java
+++ b/src/main/java/com/bergerkiller/bukkit/common/server/PaperSpigotServer.java
@@ -9,7 +9,7 @@ public class PaperSpigotServer extends SpigotServer {
 
     @Override
     public boolean init() {
-        if (!super.init() || !Bukkit.getServer().getVersion().contains("PaperSpigot")) {
+        if (!super.init() || !Bukkit.getServer().getVersion().contains("Paper")) {
             return false;
         }
         return true;
@@ -17,6 +17,6 @@ public class PaperSpigotServer extends SpigotServer {
 
     @Override
     public String getServerName() {
-        return "PaperSpigot";
+        return "Paper(Spigot)";
     }
 }


### PR DESCRIPTION
As of 1.9 ([this commit](https://github.com/PaperMC/Paper/commit/86a8f39fea199117233bd3d8f083d734babdb2c3)), PaperSpigot is now known as Paper, meaning the server's version string only contains "Paper", not "PaperSpigot". Simply looking for "Paper" will detect both "Paper" and "PaperSpigot"