### PR TITLE
Include build in version subcommand

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/common/PluginBase.java
+++ b/src/main/java/com/bergerkiller/bukkit/common/PluginBase.java
@@ -876,7 +876,7 @@ public abstract class PluginBase extends JavaPlugin {
      * @return True if the version command was handled
      */
     public boolean onVersionCommand(String command, CommandSender sender) {
-        sender.sendMessage(ChatColor.GREEN + this.getName() + " v" + this.getVersion() + " using BKCommonLib v" + CommonPlugin.getInstance().getVersion());
+        sender.sendMessage(ChatColor.GREEN + this.getName() + " v" + this.getDebugVersion() + " using BKCommonLib v" + CommonPlugin.getInstance().getDebugVersion());
         return true;
     }
 


### PR DESCRIPTION
New output of /train version:
![Train_Carts v1.13-v1-SNAPSHOT (build: 385) using BKCommonLib v1.13-v1-SNAPSHOT (build: 402)](https://i.imgur.com/LNEASiI.png)