### PR TITLE
Add user agent so download of resource pack doesn't fail

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/common/map/archive/MapResourcePackDownloadedArchive.java
+++ b/src/main/java/com/bergerkiller/bukkit/common/map/archive/MapResourcePackDownloadedArchive.java
@@ -182,6 +182,7 @@ public class MapResourcePackDownloadedArchive implements MapResourcePackArchive 
         URLConnection con;
         try {
             con = this.resourcePackURL.openConnection();
+            con.addRequestProperty("User-Agent", "BKCommonLib/" + CommonPlugin.getInstance().getVersion());
             con.setReadTimeout(10000);
         } catch (IOException ex) {
             log.log(Level.SEVERE, "Failed to start download for " + this.resourcePackURL, ex);


### PR DESCRIPTION
Cloudflare likes to block any traffic without a set user agent field and clouldflare is widely used.

I wasn't able to test this as maven was being stupid, but it should work just fine.