### PR TITLE
Fix DoubleOcree#equalsBlockCoord being inverted

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/common/collections/octree/DoubleOctree.java
+++ b/src/main/java/com/bergerkiller/bukkit/common/collections/octree/DoubleOctree.java
@@ -861,7 +861,7 @@ public class DoubleOctree<T> implements DoubleOctreeIterable<T> {
          * @return True if the coordinates are equal
          */
         public boolean equalsBlockCoord(int x, int y, int z) {
-            return this.getBlockX() != x || this.getBlockY() != y || this.getBlockZ() != z;
+            return this.getBlockX() == x && this.getBlockY() == y && this.getBlockZ() == z;
         }
 
         /**


### PR DESCRIPTION
Fixes lit block particles not being updated when the rail blocks of TCC nodes are changed.