### PR TITLE
Add printing of Server version used.

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/common/PluginBase.java
+++ b/src/main/java/com/bergerkiller/bukkit/common/PluginBase.java
@@ -882,7 +882,8 @@ public abstract class PluginBase extends JavaPlugin {
      * @return True if the version command was handled
      */
     public boolean onVersionCommand(String command, CommandSender sender) {
-        sender.sendMessage(ChatColor.GREEN + this.getName() + " v" + this.getDebugVersion() + " using BKCommonLib v" + CommonPlugin.getInstance().getDebugVersion());
+        sender.sendMessage(ChatColor.GREEN + this.getName() + ": v" + this.getDebugVersion());
+        sender.sendMessage(ChatColor.GREEN + "BKCommonLib: v" + CommonPlugin.getInstance().getDebugVersion());
         sender.sendMessage(ChatColor.GREEN + "Server: " + getServer().getVersion());
         return true;
     }

--- a/src/main/java/com/bergerkiller/bukkit/common/PluginBase.java
+++ b/src/main/java/com/bergerkiller/bukkit/common/PluginBase.java
@@ -883,6 +883,7 @@ public abstract class PluginBase extends JavaPlugin {
      */
     public boolean onVersionCommand(String command, CommandSender sender) {
         sender.sendMessage(ChatColor.GREEN + this.getName() + " v" + this.getDebugVersion() + " using BKCommonLib v" + CommonPlugin.getInstance().getDebugVersion());
+        sender.sendMessage(ChatColor.GREEN + "Server: " + getServer().getVersion());
         return true;
     }
 


### PR DESCRIPTION
This adds `Server: <getServer().getVersion()` to the version command to also get which server version is used.
The server version in itself also contains the required info like build and MC version.

I personally suggest to perhaps update the format of this command to something like this for easier readability:
```
<plugin>: v<version>
BkCommonLib: v<BkVersion>
Server: <server version>
```

I'll wait on feedback before opening this PR to be merged.