### PR TITLE
[CI-SKIP] Update javadocs link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BKCommonLib
-[Spigot Resource Page](https://www.spigotmc.org/resources/bkcommonlib.39590/) | [Dev Builds](https://ci.mg-dev.eu/job/BKCommonLib/) | [Javadocs](https://jd.mg-dev.eu/BKCommonLib)
+[Spigot Resource Page](https://www.spigotmc.org/resources/bkcommonlib.39590/) | [Dev Builds](https://ci.mg-dev.eu/job/BKCommonLib/) | [Javadocs](https://ci.mg-dev.eu/javadocs/BKCommonLib/)
 
 To build BKCommonLib you will (probably) need to run [Build Tools](https://www.spigotmc.org/wiki/buildtools/) beforehand.
 Otherwise tests will fail and maven will complain. No actual server code is linked during compiling, hence the dependency is type test.


### PR DESCRIPTION
resolves GH-113

You were so caught up discussing how to and where to host the javadocs you forgot to update the readme 😊